### PR TITLE
[incidentist] Add validation for search start and end dates

### DIFF
--- a/main.go
+++ b/main.go
@@ -59,6 +59,9 @@ func main() {
 	if err != nil {
 		exit("Failed to parse --until: %v", err)
 	}
+	if untilAt.Before(sinceAt) {
+		exit(fmt.Sprintf("--since must start before --until. --since: %s, --until: %s", *since, *until))
+	}
 
 	incidents, err := fetchIncidents(*team, sinceAt, untilAt)
 	if err != nil {


### PR DESCRIPTION
Currently if the search start date specified in `--since` comes after the search end date specified in `--until`, the dates are passed on to the Pagerduty incident search API, and the error message that ends up being shown is rather inscrutable:
```
Failed to fetch PagerDuty pages: HTTP response failed with status code 400, message: Invalid Input Provided (code: 2001):  is invalid.
exit status 255
```

This change adds validation to ensure that the search start date comes before the search end date, and returns a more helpful error if this occurs:
```
--since must start before --until. --since: 2023-06-28, --until: 2022-07-11
exit status 255
```

