### PR TITLE
Add uploading functionality

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,7 @@ require (
 	github.com/PagerDuty/go-pagerduty v1.7.0
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20210208195552-ff826a37aa15 // indirect
+	github.com/yuin/goldmark v1.7.1
+	golang.org/x/text v0.3.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 )

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/yuin/goldmark v1.7.1 h1:3bajkSilaCbjdKVsKdZjZCLBNPL9pYzrCakKaf4U49U=
+github.com/yuin/goldmark v1.7.1/go.mod h1:uzxRWxtg69N339t3louHJ7+O03ezfj6PlliRlaOzY1E=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200414173820-0848c9571904/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -66,6 +68,7 @@ golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=

--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ func main() {
 			exit("missing confluence auth token (CONFLUENCE_API_TOKEN)")
 		}
 		if *spaceKey == "" {
-			exit("missing space key (--space-key)")
+			exit("missing space key (--confluence-space)")
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -20,9 +20,9 @@ var (
 	replace    = kingpin.Flag("replace", "Replace titles with regex").Strings()
 	tagFilters = kingpin.Flag("tags", "Filter PagerDuty incidents by Datadog tags").Strings()
 	// Params for uploading the report
-	confSubdomain = kingpin.Flag("subdomain", "Confluence subdomain").String()
-	spaceKey      = kingpin.Flag("space", "Confluence space key").String()
-	parentId      = kingpin.Flag("parent", "Confluence parent page id").String()
+	subdomain = kingpin.Flag("confluence-subdomain", "Confluence subdomain").String()
+	spaceKey  = kingpin.Flag("confluence-space", "Confluence space key").String()
+	parentId  = kingpin.Flag("confluence-parent", "Confluence parent page id").String()
 )
 
 func errorf(format string, a ...interface{}) {
@@ -56,7 +56,7 @@ func main() {
 	}
 
 	var confUsername, confToken string
-	doUpload := *confSubdomain != ""
+	doUpload := *subdomain != ""
 	if doUpload {
 		// Only check these credentials if we want to upload to confluence
 		confUsername = os.Getenv("CONFLUENCE_USERNAME")
@@ -92,7 +92,7 @@ func main() {
 		exit("error generating report: %v", err)
 	} else if doUpload {
 		uploadRequest := report.UploadRequest{
-			ConfluenceSubdomain: *confSubdomain,
+			ConfluenceSubdomain: *subdomain,
 			ConfluenceUsername:  confUsername,
 			ConfluenceToken:     confToken,
 			SpaceKey:            *spaceKey,
@@ -106,7 +106,7 @@ func main() {
 			fmt.Println("Report uploaded successfully")
 		}
 	} else {
-		// If not uploading, just dump to stderr.
+		// If not uploading, just dump to stdout.
 		fmt.Println(content)
 	}
 }

--- a/report/upload_report.go
+++ b/report/upload_report.go
@@ -17,12 +17,8 @@ import (
 	"github.com/yuin/goldmark/renderer/html"
 )
 
-const (
-	YYYYMMDD = "2006-01-02"
-)
-
-// ConfluencePage represents the JSON payload to create a new Confluence page
-type ConfluencePage struct {
+// confluencePage represents the JSON payload to create a new Confluence page
+type confluencePage struct {
 	Type  string `json:"type"`
 	Title string `json:"title"`
 	Space struct {
@@ -99,12 +95,12 @@ func Upload(request UploadRequest) error {
 
 	// Try to come up with some title if we couldn't parse one
 	if title == "" {
-		title = fmt.Sprintf("On-Call Report %s", time.Now().Format(YYYYMMDD))
+		title = fmt.Sprintf("On-Call Report %s", time.Now().Format(time.DateOnly))
 	}
 
 	baseURL := fmt.Sprintf("https://%s.atlassian.net/wiki/rest/api/content", request.ConfluenceSubdomain)
 	// Prepare the page payload
-	newPage := ConfluencePage{
+	newPage := confluencePage{
 		Type:  "page",
 		Title: title,
 	}

--- a/report/upload_report.go
+++ b/report/upload_report.go
@@ -1,0 +1,151 @@
+package report
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"regexp"
+	"time"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/extension"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/renderer"
+	"github.com/yuin/goldmark/renderer/html"
+)
+
+const (
+	YYYYMMDD = "2006-01-02"
+)
+
+// ConfluencePage represents the JSON payload to create a new Confluence page
+type ConfluencePage struct {
+	Type  string `json:"type"`
+	Title string `json:"title"`
+	Space struct {
+		Key string `json:"key"`
+	} `json:"space"`
+	Ancestors []struct { // Add this field to specify the parent page
+		ID string `json:"id"`
+	} `json:"ancestors,omitempty"`
+	Body struct {
+		Storage struct {
+			Value          string `json:"value"`
+			Representation string `json:"representation"`
+		} `json:"storage"`
+	} `json:"body"`
+}
+
+type UploadRequest struct {
+	ConfluenceSubdomain string
+	ConfluenceUsername  string
+	ConfluenceToken     string
+	SpaceKey            string
+	ParentId            string
+	MarkdownContent     string
+}
+
+// pruneMarkdownTitle removes the title header from the markdown, if found.
+// It expects the markdown to look like:
+// ---
+// title: Some Title
+// ---
+// Some content
+func pruneMarkdownTitle(content string) (string, string) {
+	r := regexp.MustCompile(`---\ntitle: (.*)\n---\n`)
+	title := ""
+	// Find match groups
+	matches := r.FindStringSubmatch(content)
+	if matches != nil && len(matches) > 1 {
+		title = matches[1]
+	}
+
+	// Remove the entire match from the original string
+	return r.ReplaceAllString(content, ""), title
+}
+
+// convertMarkdown converts Markdown format into HTML, which is expected by Confluence
+func convertMarkdown(s string) (string, error) {
+	renderOptions := []renderer.Option{
+		html.WithXHTML(),
+	}
+
+	md := goldmark.New(
+		goldmark.WithExtensions(extension.GFM, extension.DefinitionList),
+		goldmark.WithParserOptions(
+			parser.WithAutoHeadingID(),
+		),
+		goldmark.WithRendererOptions(renderOptions...),
+	)
+
+	var buf bytes.Buffer
+	if err := md.Convert([]byte(s), &buf); err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}
+
+// Upload creates a new Confluence page with the given details
+func Upload(request UploadRequest) error {
+	content, title := pruneMarkdownTitle(request.MarkdownContent)
+	content, err := convertMarkdown(content)
+	if err != nil {
+		return fmt.Errorf("error converting markdown: %v", err)
+	}
+
+	// Try to come up with some title if we couldn't parse one
+	if title == "" {
+		title = fmt.Sprintf("On-Call Report %s", time.Now().Format(YYYYMMDD))
+	}
+
+	baseURL := fmt.Sprintf("https://%s.atlassian.net/wiki/rest/api/content", request.ConfluenceSubdomain)
+	// Prepare the page payload
+	newPage := ConfluencePage{
+		Type:  "page",
+		Title: title,
+	}
+	if request.ParentId != "" {
+		newPage.Ancestors = []struct {
+			ID string `json:"id"`
+		}{{ID: request.ParentId}}
+	}
+
+	newPage.Space.Key = request.SpaceKey
+	newPage.Body.Storage.Value = content
+	newPage.Body.Storage.Representation = "storage"
+
+	pageData, err := json.Marshal(newPage)
+	if err != nil {
+		return fmt.Errorf("error marshalling json: %v", err)
+	}
+
+	httpReq, err := http.NewRequest("POST", baseURL, bytes.NewBuffer(pageData))
+	if err != nil {
+		return fmt.Errorf("error creating request: %v", err)
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.SetBasicAuth(request.ConfluenceUsername, request.ConfluenceToken)
+
+	client := &http.Client{}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("error making request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("error reading response body: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		fmt.Fprintf(os.Stderr, "Error response body: %s", string(body))
+		return fmt.Errorf("failed to create page, status code: %d", resp.StatusCode)
+	}
+	return nil
+}


### PR DESCRIPTION
Adds functionality to upload a report to Confluence.

This is composed of two key steps:
1. Converting the report to HTML, which Confluence expects. Although one can paste markdown into Confluence directly, doing so uses the UI/Editor functionality, and thus is not possible via the API. So, the conversion needs to happen manually.
2. Actually uploading the converted report to Confluence.

New flags added:

```
subdomain     = kingpin.Flag("confluence-subdomain", "Confluence subdomain").String()
spaceKey      = kingpin.Flag("confluence-space", "Confluence space key").String()
parentId      = kingpin.Flag("confluence-parent", "Confluence parent page id").String()
```

If the `--confluence-subdomain` flag is specified, which is what triggers uploading, then the following ENV vars are expected:
```
CONFLUENCE_USERNAME
CONFLUENCE_API_TOKEN
```

If the `--confluence-subdomain` flag is not passed, the util dumps to stderr as before.