### PR TITLE
Support matching Pagerduty alerts if any tag filter is found 

### DIFF
--- a/report/search_pages.go
+++ b/report/search_pages.go
@@ -156,10 +156,10 @@ func pagerdutyIncidentMatchesTags(client *pagerduty.Client, incidentId string, t
 			continue
 		}
 
-		found := true
+		found := false
 		for _, tagFilter := range tagFilters {
-			if _, ok := alertTags[tagFilter]; !ok {
-				found = false
+			if _, ok := alertTags[tagFilter]; ok {
+				found = true
 				break
 			}
 		}


### PR DESCRIPTION
https://github.com/xornivore/incidentist/pull/11 added support for collecting incidents and pages from multiple teams. However, one use of the `tags` argument is to filter Pagerduty alerts by team. The current implementation of alert filtering requires the Pagerduty alerts to match all tag filters, which does not work for the case where there are alerts with only a single team tag.

This changes the implementation of the alert filtering to instead return a match if any tag filter is present, instead of if all tag filters are present.